### PR TITLE
Fix RPi4-64 builds for traefik

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -9,7 +9,8 @@ COPY run.sh /
 
 RUN apk add --no-cache python3 py3-pip nginx && \
     pip3 install "j2cli[yaml]" && \
-    wget --quiet -O /tmp/traefik.tar.gz "https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_v${TRAEFIK_VERSION}_linux_${BUILD_ARCH}.tar.gz" && \
+    if [ "$BUILD_ARCH" == "aarch64" ];then TRAEFIK_BUILD_ARCH=arm64;else TRAEFIK_BUILD_ARCH=$BUILD_ARCH;fi && \
+    wget --quiet -O /tmp/traefik.tar.gz "https://github.com/containous/traefik/releases/download/v${TRAEFIK_VERSION}/traefik_v${TRAEFIK_VERSION}_linux_${TRAEFIK_BUILD_ARCH}.tar.gz" && \
     tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik && \
     chmod a+x /usr/local/bin/traefik && \
     chmod a+x /run.sh && \


### PR DESCRIPTION
Prior to this change, the wget command used to pull the release of
traefik made use of the BUILD_ARCH environment variable, which on a
Raspberry Pi 4 with a 64 bit system was the string "aarch64". Traefik's
releases for the 64-bit ARM architecture however use "arm64", which
resulted in the release file not being found and the addon container
failing to build. This change fixes the issue by using a TRAEFIK_BUILD_ARCH
variable and setting that appropriately based on BUILD_ARCH.